### PR TITLE
adds support for setting signin token to cpe_slack

### DIFF
--- a/cpe_slack/README.md
+++ b/cpe_slack/README.md
@@ -5,11 +5,12 @@ Install a profile to manage slack settings
 
 Attributes
 ----------
-* node['cpe_slack']
+* node['cpe_slack']['preferences']
+* node['cpe_slack']['signin_token']
 
 Usage
 -----
-The profile will manage the `com.tinyspeck.slackmacgap` preference domain.
+The profile will manage the `com.tinyspeck.slackmacgap` preference domain with the keys in `preferences`.
 
 The profile's organization key defaults to `Uber` unless `node['organization']` is
 configured in your company's custom init recipe. The profile will also use
@@ -24,3 +25,5 @@ For a list of supported keys, please see this [Slack knowledge base article](htt
 For example, you could tweak the above values
     # Disable the ability for Slack to auto-update
     node.default['cpe_slack']['SlackNoAutoUpdates'] = true
+
+This cookbook can also set up slack to have a default signin domain, but populating a signon token. This only works if slack is already installed and `/Users/<console_user>/Library/Application Support/Slack` exists. Define `signin_token` to use. You can get your team ID for a signon token by following [these instructions](https://slack.com/intl/en-au/help/articles/360041725993-Share-a-default-sign-in-file-with-members).

--- a/cpe_slack/attributes/default.rb
+++ b/cpe_slack/attributes/default.rb
@@ -11,4 +11,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-default['cpe_slack'] = {}
+default['cpe_slack'] = {
+  'preferences' => {},
+  'signin_token' => nil
+}


### PR DESCRIPTION
Per this document: https://slack.com/intl/en-au/help/articles/360041725993-Share-a-default-sign-in-file-with-members, this PR sets a signin token if defined at `node['cpe_slack']['signin_token']`, which should be a 8-digit team ID. 

To support on non-profile key, this PR also moves Slack's profile keys to a `preferences` key. The signin_token method expect `node.console_user` to exist. It may be worth reworking this to support an arbitrary username, or to determine the slack app's owner's username more effectively.