### PR TITLE
Fix LaunchDaemon for osquery on Big Sur and higher

### DIFF
--- a/chef/cookbooks/cpe_osquery/resources/cpe_osquery.rb
+++ b/chef/cookbooks/cpe_osquery/resources/cpe_osquery.rb
@@ -172,6 +172,7 @@ action_class do # rubocop:disable Metrics/BlockLength
         '--flagfile',
         flag_file,
       ]
+      environment_variables({ 'SYSTEM_VERSION_COMPAT' => '0' }) unless node.os_at_least_or_lower?('10.15.99')
       keep_alive true
       run_at_load true
       throttle_interval 60


### PR DESCRIPTION
resulting daemon looks like

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>EnvironmentVariables</key>
	<dict>
		<key>SYSTEM_VERSION_COMPAT</key>
		<string>0</string>
	</dict>
	<key>KeepAlive</key>
	<true/>
	<key>Label</key>
	<string>com.facebook.osqueryd</string>
	<key>ProgramArguments</key>
	<array>
		<string>/usr/local/bin/osqueryd</string>
		<string>--flagfile</string>
		<string>/var/osquery/osquery.flags</string>
	</array>
	<key>RunAtLoad</key>
	<true/>
	<key>ThrottleInterval</key>
	<integer>60</integer>
</dict>
</plist>
```