### PR TITLE
Initial Implementation to Query the Linux IMA System

### DIFF
--- a/osq-exts/main.go
+++ b/osq-exts/main.go
@@ -4,12 +4,13 @@ import (
 	"flag"
 	"log"
 	"os"
-	"time"
 	"runtime"
+	"time"
 
-	"github.com/uber/client-platform-engineering/osq-exts/tables/crowdstrikefalconagent"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/uber/client-platform-engineering/osq-exts/tables/crowdstrikefalconagent"
+	"github.com/uber/client-platform-engineering/osq-exts/tables/ima"
 )
 
 const (
@@ -22,11 +23,20 @@ var (
 	socket   = flag.String("socket", "", "Path to the extensions UNIX domain socket")
 	timeout  = flag.Int("timeout", 3, "Seconds to wait for autoloaded extensions")
 	interval = flag.Int("interval", 3, "Seconds delay between connectivity checks")
+	verbose  = flag.Bool("verbose", false, "enable verbose messaging")
 )
 
 func listOfPlugins() (plugins []osquery.OsqueryPlugin) {
 	if crowdstrikefalconagent.Supported(runtime.GOOS) {
 		plugins = append(plugins, table.NewPlugin(crowdstrikefalconagent.Register()))
+	}
+
+	if imasubsys, err := ima.NewIMA(); err == nil {
+		plugins = append(plugins, table.NewPlugin(imasubsys.Register()))
+	}
+
+	if measurements, err := ima.NewMeasurements(); err == nil {
+		plugins = append(plugins, table.NewPlugin(measurements.Register()))
 	}
 
 	return

--- a/osq-exts/tables/ima/README.md
+++ b/osq-exts/tables/ima/README.md
@@ -1,0 +1,3 @@
+This extension will query the Linux Integrity Management Architecture (IMA) System.
+
+More information can be found here; https://sourceforge.net/p/linux-ima/wiki/Home/

--- a/osq-exts/tables/ima/common.go
+++ b/osq-exts/tables/ima/common.go
@@ -1,0 +1,30 @@
+package ima
+
+import (
+	"bytes"
+	"os"
+)
+
+func pathExists(path string) string {
+
+	_, err := os.Stat(path)
+	if err != nil {
+		return "false"
+	}
+
+	return "true"
+}
+
+func readFile(path, name string) (ret string) {
+	file, err := os.Open(path + name)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(file)
+	ret = buf.String()
+
+	return
+}

--- a/osq-exts/tables/ima/ima.go
+++ b/osq-exts/tables/ima/ima.go
@@ -1,0 +1,30 @@
+package ima
+
+import (
+	"context"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const (
+	_IMA_PLUGIN_NAME    = "ima"
+	_IMA_NOT_COMPATIBLE = "Not compatible with current OS."
+)
+
+type IMA struct{}
+
+func NewIMA() (ima *IMA, err error) {
+	err = ima.osCompat()
+	return
+}
+
+func (m *IMA) Columns() []table.ColumnDefinition {
+	return m.osColumns()
+}
+
+func (m *IMA) Register() (string, []table.ColumnDefinition, table.GenerateFunc) {
+	return _IMA_PLUGIN_NAME, m.Columns(), m.Generate
+}
+
+func (m *IMA) Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	return m.osGenerate(ctx, queryContext)
+}

--- a/osq-exts/tables/ima/ima_darwin.go
+++ b/osq-exts/tables/ima/ima_darwin.go
@@ -1,0 +1,19 @@
+package ima
+
+import (
+	"context"
+	"errors"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+func (m *IMA) osCompat() error {
+	return errors.New(_IMA_NOT_COMPATIBLE)
+}
+
+func (m *IMA) osColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{}
+}
+
+func (m *IMA) osGenerate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	return []map[string]string{{}}, errors.New(_IMA_NOT_COMPATIBLE)
+}

--- a/osq-exts/tables/ima/ima_linux.go
+++ b/osq-exts/tables/ima/ima_linux.go
@@ -1,0 +1,35 @@
+package ima
+
+import (
+	"context"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const (
+	_ENABLED      = "enabled"
+	_COUNT        = "runtime_measurements_count"
+	_VIOLATIONS   = "violations"
+	_IMA_BASEPATH = "/sys/kernel/security/ima/"
+)
+
+func (m *IMA) osCompat() error {
+	return nil
+}
+
+func (m *IMA) osColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn(_ENABLED),
+		table.BigIntColumn(_COUNT),
+		table.BigIntColumn(_VIOLATIONS),
+	}
+}
+
+func (m *IMA) osGenerate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	return []map[string]string{
+		{
+			_ENABLED:    pathExists(_IMA_BASEPATH),
+			_COUNT:      readFile(_IMA_BASEPATH, _COUNT),
+			_VIOLATIONS: readFile(_IMA_BASEPATH, _VIOLATIONS),
+		},
+	}, nil
+}

--- a/osq-exts/tables/ima/ima_test.go
+++ b/osq-exts/tables/ima/ima_test.go
@@ -1,0 +1,1 @@
+package ima

--- a/osq-exts/tables/ima/ima_test.go
+++ b/osq-exts/tables/ima/ima_test.go
@@ -1,1 +1,25 @@
 package ima
+
+import (
+	"testing"
+	"runtime"
+)
+
+func TestCreateNewIMA(t *testing.T) {
+	_, err := NewIMA()
+
+	switch(runtime.GOOS) {
+	case "linux":
+		if err != nil {
+			t.Fatal("Linux OS Is Supported. This should not fail.")
+		}
+	case "darwin":
+		fallthrough
+	case "windows":
+		fallthrough
+	default:
+		if err == nil {
+			t.Fatal("OS is unsupported.  This should fail.")
+		}
+	}
+}

--- a/osq-exts/tables/ima/ima_windows.go
+++ b/osq-exts/tables/ima/ima_windows.go
@@ -1,0 +1,20 @@
+package ima
+
+import (
+	"context"
+	"errors"
+
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+func (m *IMA) osCompat() error {
+	return errors.New(_IMA_NOT_COMPATIBLE)
+}
+
+func (m *IMA) osColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{}
+}
+
+func (m *IMA) osGenerate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	return []map[string]string{{}}, errors.New(_IMA_NOT_COMPATIBLE)
+}

--- a/osq-exts/tables/ima/measurements.go
+++ b/osq-exts/tables/ima/measurements.go
@@ -1,0 +1,30 @@
+package ima
+
+import (
+	"context"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const (
+	_MEASUREMENT_PLUGIN_NAME    = "ima_measurements"
+	_MEASUREMENT_NOT_COMPATIBLE = "Not compatible with current OS."
+)
+
+type Measurements struct{}
+
+func NewMeasurements() (m *Measurements, err error) {
+	err = m.osCompat()
+	return
+}
+
+func (m *Measurements) Columns() []table.ColumnDefinition {
+	return m.osColumns()
+}
+
+func (m *Measurements) Register() (string, []table.ColumnDefinition, table.GenerateFunc) {
+	return _MEASUREMENT_PLUGIN_NAME, m.Columns(), m.Generate
+}
+
+func (m *Measurements) Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	return m.osGenerate(ctx, queryContext)
+}

--- a/osq-exts/tables/ima/measurements_darwin.go
+++ b/osq-exts/tables/ima/measurements_darwin.go
@@ -1,0 +1,20 @@
+package ima
+
+import (
+	"context"
+	"errors"
+
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+func (m *Measurements) osCompat() error {
+	return errors.New(_MEASUREMENT_NOT_COMPATIBLE)
+}
+
+func (m *Measurements) osColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{}
+}
+
+func (m *Measurements) osGenerate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	return []map[string]string{{}}, errors.New(_MEASUREMENT_NOT_COMPATIBLE)
+}

--- a/osq-exts/tables/ima/measurements_linux.go
+++ b/osq-exts/tables/ima/measurements_linux.go
@@ -1,0 +1,56 @@
+package ima
+
+import (
+	"context"
+	"github.com/osquery/osquery-go/plugin/table"
+	"strings"
+)
+
+const (
+	_PCR                  = "PCR"
+	_IMA_HASH             = "IMA_HASH"
+	_TEMPLATE             = "Template"
+	_HASH_TYPE            = "HashType"
+	_HASH_VALUE           = "FileHash"
+	_FILENAME             = "FileName"
+	_IMA_SIG              = "IMASignature"
+	_MEASUREMENT_BASEPATH = "/sys/kernel/security/ima/"
+	_ASCII_RM             = "ascii_runtime_measurements"
+)
+
+func (m *Measurements) osCompat() error {
+	return nil
+}
+
+func (m *Measurements) osColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.BigIntColumn(_PCR),
+		table.TextColumn(_IMA_HASH),
+		table.TextColumn(_TEMPLATE),
+		table.TextColumn(_HASH_TYPE),
+		table.TextColumn(_HASH_VALUE),
+		table.TextColumn(_FILENAME),
+	}
+}
+
+func (m *Measurements) osGenerate(ctx context.Context, queryContext table.QueryContext) (ret []map[string]string, err error) {
+	ascii_runtime_measurements := readFile(_MEASUREMENT_BASEPATH, _ASCII_RM)
+	for _, line := range strings.Split(strings.TrimSuffix(ascii_runtime_measurements, "\n"), "\n") {
+
+		elem := strings.Split(line, " ")
+
+		current := map[string]string{
+			_PCR: elem[0],
+			_IMA_HASH: elem[1],
+			_TEMPLATE: elem[2],
+			_HASH_TYPE: strings.Split(elem[3], ":")[0],
+			_HASH_VALUE: strings.Split(elem[3], ":")[1],
+			_FILENAME: elem[4],
+		}
+
+		ret = append(ret, current)
+
+	}
+
+	return
+}

--- a/osq-exts/tables/ima/measurements_test.go
+++ b/osq-exts/tables/ima/measurements_test.go
@@ -1,1 +1,25 @@
 package ima
+
+import (
+	"testing"
+	"runtime"
+)
+
+func TestCreateNewMeasurements(t *testing.T) {
+	_, err := NewMesaurements()
+
+	switch(runtime.GOOS) {
+	case "linux":
+		if err != nil {
+			t.Fatal("Linux OS Is Supported. This should not fail.")
+		}
+	case "darwin":
+		fallthrough
+	case "windows":
+		fallthrough
+	default:
+		if err == nil {
+			t.Fatal("OS is unsupported.  This should fail.")
+		}
+	}
+}

--- a/osq-exts/tables/ima/measurements_test.go
+++ b/osq-exts/tables/ima/measurements_test.go
@@ -1,0 +1,1 @@
+package ima

--- a/osq-exts/tables/ima/measurements_test.go
+++ b/osq-exts/tables/ima/measurements_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCreateNewMeasurements(t *testing.T) {
-	_, err := NewMesaurements()
+	_, err := NewMeasurements()
 
 	switch(runtime.GOOS) {
 	case "linux":

--- a/osq-exts/tables/ima/measurements_windows.go
+++ b/osq-exts/tables/ima/measurements_windows.go
@@ -1,0 +1,19 @@
+package ima
+
+import (
+	"context"
+	"errors"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+func (m *Measurements) osCompat() error {
+	return errors.New(_MEASUREMENT_NOT_COMPATIBLE)
+}
+
+func (m *Measurements) osColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{}
+}
+
+func (m *Measurements) osGenerate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	return []map[string]string{{}}, errors.New(_MEASUREMENT_NOT_COMPATIBLE)
+}


### PR DESCRIPTION
This extension will query the Linux Integrity Management Architecture (IMA) System.

Querying IMA will be useful for;
1. Getting SHA256 hashes of objects that have been executed.
2. Getting Secure Boot Measurements
3. Getting the IMA System Status (enabled/disabled)

Examples;
-- Subsystem Status
```
osquery> select * from ima;
+---------+----------------------------+------------+
| enabled | runtime_measurements_count | violations |
+---------+----------------------------+------------+
| true    | 7006                       | 6          |
+---------+----------------------------+------------+
```
-- File Measurements.
```
osquery> select * from ima_measurements where Filename like '%boot%';
+-----+------------------------------------------+----------+----------+------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
| PCR | IMA_HASH                                 | Template | HashType | HASH                                                             | Filename                                                                                                  |
+-----+------------------------------------------+----------+----------+------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
| 10  | 0adefe762c149c7cec19da62f0da1297fcfbffff | ima-ng   | sha256   | 0000000000000000000000000000000000000000000000000000000000000000 | boot_aggregate                                                                                            |
| 10  | 105e6bf1820b078b911d1e103e616351741b0936 | ima-ng   | sha256   | b755de86d29d0ce8896dd5cb6b8e31f6600b5ba572253c85327484e363124c4e | /usr/lib/systemd/system-generators/systemd-bless-boot-generator                                           |
| 10  | 3190a9e0e4cbd75720d8e72373c438eccdbd1ee5 | ima-ng   | sha256   | 5ebb2853e945bda01ab91541e62784d09de81e7cca8983c7b0b1efdff0a07c1b | /usr/lib/systemd/system/systemd-boot-system-token.service                                                 |
| 10  | 36d0843ee6c88eb39f856fac2d5555ecbcc5c5f2 | ima-ng   | sha256   | edf0aa0ee6566c2e2d442d68e35d19567aeed25325257b1f94b7c144cc6eff57 | /usr/lib/systemd/system/ua-reboot-cmds.service                                                            |
| 10  | 72816acfc47ceacc4c3b217c3dd5c04f41191eb6 | ima-ng   | sha256   | de402b1c28fe6608bb9d3098fe5e1725df6b8596b7962953a2cda29b5bd29a81 | /usr/lib/systemd/system/secureboot-db.service                                                             |
| 10  | 8e689d82b8e492139c6beca55c42d68d5f22783a | ima-ng   | sha256   | 203bd0f03b8fca64c939b58590b7a82f90f9c45db5f98dc3e21d62c2063c2641 | /usr/lib/python3.8/__pycache__/_bootlocale.cpython-38.pyc                                                 |
| 10  | b80994edda15d597442081be2cbe06998672fee6 | ima-ng   | sha256   | 038f330fff790ecad610f730ecdbccc01b1361adde1b24da8c6401544ede9ac8 | /usr/lib/python3/dist-packages/cloudinit/handlers/__pycache__/boot_hook.cpython-38.pyc                    |
| 10  | 55c33d957ef53f797eab8ef16aa5e6be259c78fb | ima-ng   | sha256   | 94c13dbffc78b1e3f4ab84a1904f8d3ae34af41b1c73081f9dbf83b1d3eedcd2 | /usr/lib/python3/dist-packages/cloudinit/config/__pycache__/cc_bootcmd.cpython-38.pyc                     |
| 10  | e552f2d88b3ee6c0fd9d2672030dc68bc72fa4b1 | ima-ng   | sha256   | 42439fda5143449c668430706de270c764912b08766180e594bcd75d961da46c | /boot/grub/grubenv                                                                                        |
| 10  | e97cc3109557d4930cf55feabdea4233997f1665 | ima-ng   | sha256   | f1569cf6ff5606931805f67279e5d5e750893648beebed7b35916b434122f2b4 | /boot/grub/grubenv                                                                                        |
| 10  | b1ee1aadd1a522ecdca155fbb558bd6665e45e55 | ima-ng   | sha256   | 2e4234c851ddf251b0ffc935ee1db96b7befd4f2df869a5612e282de04c23fc0 | /boot/grub/grubenv                                                                                        |
| 10  | 12043fdd5256424d89495bd117439d37711d4874 | ima-ng   | sha256   | 69607c274f66d3c98c5a120a71eea3ed01f0af35fe2e7697195194ba7a383e4c | /usr/lib/python3/dist-packages/cloudinit/config/__pycache__/cc_scripts_per_boot.cpython-38.pyc            |
| 10  | c663df164da39ef24c726a138b38c1ca578d610d | ima-ng   | sha256   | 5b351c42bfa7f66f926871d7cc33dd727e8ed6e4960fed14716a6979a5319236 | /etc/update-motd.d/98-fsck-at-reboot                                                                      |
| 10  | b067615e414088360218488d83c6d958f21dfcc2 | ima-ng   | sha256   | 88b40e43ddc24e66a2056388ac737f018af1cf92ce878431927226ced511f731 | /usr/lib/update-notifier/update-motd-fsck-at-reboot                                                       |
| 10  | e88d836413269bb23597326ed49965ce4f0f2630 | ima-ng   | sha256   | e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 | /var/lib/update-notifier/fsck-at-reboot                                                                   |
| 10  | 85ef88f6d4801ab05d927e404886370d794e9b25 | ima-ng   | sha256   | ede15e980ec54e7211923a42b77531ee06a15e2a728f645004b4c0fff3d660f7 | /etc/update-motd.d/98-reboot-required                                                                     |
| 10  | f03f8525d0dc2806a8240e813bbcf4dcfcc37e43 | ima-ng   | sha256   | e18f8d28bdff7d892991fb2c9d723964672f651225aaf03fe3848c215da1ecbe | /usr/lib/update-notifier/update-motd-reboot-required                                                      |
| 10  | 40b6611e6d45f67b11dfdb25bd6c5b9c622aecec | ima-ng   | sha256   | 6ab90cdcddf358e681704da1011df3c504b9805e4a65f0bd724b36922153681a | /usr/lib/python3/dist-packages/cloudinit/sources/helpers/vmware/imc/__pycache__/boot_proto.cpython-38.pyc |
| 10  | 9cb233c1a9150e2046287ce7e63b5a78eb7c53ac | ima-ng   | sha256   | 864f1172268fbc54a6e8ed66ba1158cae8c1707517ff36c1734a97bb3d0e7f21 | /usr/lib/python3.8/_bootlocale.py                                                                         |
| 10  | 86907f717a1499783f907a41c3e6f0906bd2c56a | ima-ng   | sha256   | 334191e6bafb427c350303838cf7a4894df921453a64fe5d02b0c538e2cdf3da | /usr/lib/python3.8/importlib/_bootstrap.py                                                                |
| 10  | 8540b909ddde016c4e794e657d98a0e14da7bf91 | ima-ng   | sha256   | e1190b6ffe87867ff6600d50a81bebda60a59c3062b8f0683ee7f6bdddfee451 | /usr/lib/python3.8/importlib/_bootstrap_external.py                                                       |
| 10  | a73a9672a7612f11d99bb8d14b63fbc14ae2acdd | ima-ng   | sha256   | 48493c6b55ddf711d613d7fb0a9b845f4a79eb3b313c65661bd8e6dae89950f5 | /usr/lib/x86_64-linux-gnu/libefiboot.so.1.37                                                              |
| 10  | a2faa590997c9f6da7a6ed76df61cc9a0e788d94 | ima-ng   | sha256   | 00f9b98a73c30b48048e0a0791619f7b7b7341d80b1ba916c348ad581426b28f | /usr/lib/x86_64-linux-gnu/fwupd-plugins-3/libfu_plugin_fastboot.so                                        |
| 10  | 6cbd28a71eb1bf329aee2442bdcbc304dbc6e6d1 | ima-ng   | sha256   | fd6114e2b3f53f8bc061bf3b18adf46bc8b7cd238793bdf8d9ba1caa0492aee2 | /usr/share/fwupd/quirks.d/fastboot.quirk                                                                  |
| 10  | 46618404e3ad773acc2a5c9daac49f1bfde2545a | ima-ng   | sha256   | f8384c13504a01676cedb4aeea4e0ac9c1eec8000a5dedc74e524c25c4c656ec | /etc/logrotate.d/bootlog                                                                                  |
+-----+------------------------------------------+----------+----------+------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
```