### PR TITLE
OpenDNS OSQuery Custom Extension

### DIFF
--- a/osq-exts/Makefile
+++ b/osq-exts/Makefile
@@ -1,12 +1,12 @@
 all: build
 
 build:
-	GOOS=darwin GOARCH=amd64 go build -o ./build/darwin/darwin.osq.amd64.ext
-	GOOS=darwin GOARCH=arm64 go build -o ./build/darwin/darwin.osq.arm64.ext
-	GOOS=linux GOARCH=amd64 go build -o ./build/linux/linux.osq.amd64.ext
-	GOOS=linux GOARCH=arm64 go build -o ./build/linux/linux.osq.arm64.ext
-	GOOS=windows GOARCH=amd64 go build -o ./build/windows/windows.osq.amd64.ext.exe
-	GOOS=windows GOARCH=arm64 go build -o ./build/windows/windows.osq.arm64.ext.exe
+	GOOS=darwin GOARCH=amd64 GODEBUG=netdns=cgo+2 go build -o ./build/darwin/darwin.osq.amd64.ext
+	GOOS=darwin GOARCH=arm64 GODEBUG=netdns=cgo+2 go build -o ./build/darwin/darwin.osq.arm64.ext
+	GOOS=linux GOARCH=amd64 GODEBUG=netdns=cgo+2 go build -o ./build/linux/linux.osq.amd64.ext
+	GOOS=linux GOARCH=arm64 GODEBUG=netdns=cgo+2 go build -o ./build/linux/linux.osq.arm64.ext
+	GOOS=windows GOARCH=amd64 GODEBUG=netdns=cgo+2 go build -o ./build/windows/windows.osq.amd64.ext.exe
+	GOOS=windows GOARCH=arm64 GODEBUG=netdns=cgo+2 go build -o ./build/windows/windows.osq.arm64.ext.exe
 
 test:
 	go test -race -cover ./...

--- a/osq-exts/Makefile
+++ b/osq-exts/Makefile
@@ -1,12 +1,12 @@
 all: build
 
 build:
-	GOOS=darwin GOARCH=amd64 GODEBUG=netdns=cgo+2 go build -o ./build/darwin/darwin.osq.amd64.ext
-	GOOS=darwin GOARCH=arm64 GODEBUG=netdns=cgo+2 go build -o ./build/darwin/darwin.osq.arm64.ext
-	GOOS=linux GOARCH=amd64 GODEBUG=netdns=cgo+2 go build -o ./build/linux/linux.osq.amd64.ext
-	GOOS=linux GOARCH=arm64 GODEBUG=netdns=cgo+2 go build -o ./build/linux/linux.osq.arm64.ext
-	GOOS=windows GOARCH=amd64 GODEBUG=netdns=cgo+2 go build -o ./build/windows/windows.osq.amd64.ext.exe
-	GOOS=windows GOARCH=arm64 GODEBUG=netdns=cgo+2 go build -o ./build/windows/windows.osq.arm64.ext.exe
+	GOOS=darwin GOARCH=amd64 go build -o ./build/darwin/darwin.osq.amd64.ext
+	GOOS=darwin GOARCH=arm64 go build -o ./build/darwin/darwin.osq.arm64.ext
+	GOOS=linux GOARCH=amd64 go build -o ./build/linux/linux.osq.amd64.ext
+	GOOS=linux GOARCH=arm64 go build -o ./build/linux/linux.osq.arm64.ext
+	GOOS=windows GOARCH=amd64 go build -o ./build/windows/windows.osq.amd64.ext.exe
+	GOOS=windows GOARCH=arm64 go build -o ./build/windows/windows.osq.arm64.ext.exe
 
 test:
 	go test -race -cover ./...

--- a/osq-exts/README.md
+++ b/osq-exts/README.md
@@ -4,3 +4,5 @@ This repo will contain custom osquery plugins to help manage Uber's fleet at sca
 
 We have the following custom extensions:
 - Crowdstrike Falcon Agent 6.18+ (macOS Only)
+- Linux Integrity Management Table (Linux Only with IMA Services Enabled)
+- OpenDNS Debug Information (macOS, Windows, Linux)

--- a/osq-exts/main.go
+++ b/osq-exts/main.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"flag"
-	"log"
-	"os"
-	"runtime"
-	"time"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/logger"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/uber/client-platform-engineering/osq-exts/tables/crowdstrikefalconagent"
 	"github.com/uber/client-platform-engineering/osq-exts/tables/ima"
+	"github.com/uber/client-platform-engineering/osq-exts/tables/opendns"
+	"log"
+	"os"
+	"time"
 )
 
 const (
@@ -38,6 +38,11 @@ func listOfPlugins() (plugins []osquery.OsqueryPlugin) {
 
 	if measurements, err := ima.NewMeasurements(); err == nil {
 		plugins = append(plugins, table.NewPlugin(measurements.Register()))
+	}
+
+	if opendns, err := opendns.New(); err == nil {
+		plugins = append(plugins, table.NewPlugin(opendns.Register()))
+		plugins = append(plugins, logger.NewPlugin(opendns.Logger()))
 	}
 
 	return

--- a/osq-exts/tables/opendns/README.md
+++ b/osq-exts/tables/opendns/README.md
@@ -1,0 +1,33 @@
+# OpenDNS OSQuery Extension
+
+This table reads information from debug.opendns.com for diagnostic information.
+
+macOS, Windows, and Linux are supported.
+
+```
+osquery> select * from opendns;
++--------------+-------------------------------------------------------+
+| key          | value                                                 |
++--------------+-------------------------------------------------------+
+| server       | m1234.abcd                                            |
+| device       | 1234567890123456                                      |
+| organization | id 123456                                             |
+| alt          | uid 123412341234123412341234123412341                 |
+| remoteip     | 192.168.0.1                                           |
+| flags        | 00000000 0 00 000000000000000000000000000000000000000 |
+| originid     | 123456789                                             |
+| orgid        | 123456                                                |
+| orgflags     | 12345678                                              |
+| actype       | X                                                     |
+| bundle       | 1234567                                               |
+| source       | 1.2.3.4:51280                                         |
+| dnscrypt     | enabled (0000000000000000)                            |
++--------------+-------------------------------------------------------+
+osquery> select * from opendns where key='server';
++--------+---------+
+| key    | value   |
++--------+---------+
+| server | m12.345 |
++--------+---------+
+osquery>
+```

--- a/osq-exts/tables/opendns/opendns.go
+++ b/osq-exts/tables/opendns/opendns.go
@@ -1,0 +1,99 @@
+package opendns
+
+import (
+	"context"
+	"log"
+	"net"
+	"strings"
+	"fmt"
+
+	"github.com/osquery/osquery-go/plugin/logger"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const (
+	_PLUGIN_NAME   = "opendns"
+	_DEBUG_OPENDNS = "debug.opendns.com"
+	_ACTIVE        = "active"
+	_SERVER        = "server"
+	_ORIGINID      = "originid"
+	_SOURCE        = "source"
+	_ACTYPE        = "actype"
+	_ORGID         = "orgid"
+	_BUNDLE        = "bundle"
+	_DEVICE        = "device"
+	_USER          = "user"
+	_DNSCRYPT      = "dnscrypt"
+)
+
+type OpenDNS struct{}
+
+func New() (odns *OpenDNS, err error) {
+	return
+}
+
+func (odns *OpenDNS) Columns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.BigIntColumn(_ACTIVE),
+		table.TextColumn(_SERVER),
+		table.TextColumn(_SOURCE),
+		table.TextColumn(_DNSCRYPT),
+		table.TextColumn(_USER),
+		table.TextColumn(_DEVICE),
+		table.BigIntColumn(_ORIGINID),
+		table.BigIntColumn(_ACTYPE),
+		table.BigIntColumn(_ORGID),
+		table.BigIntColumn(_BUNDLE),
+	}
+}
+
+func (odns *OpenDNS) Register() (string, []table.ColumnDefinition, table.GenerateFunc) {
+	return _PLUGIN_NAME, odns.Columns(), odns.Generate
+}
+
+func (odns *OpenDNS) Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	txtrecords, err := getTXTRecords(ctx, _DEBUG_OPENDNS)
+	if err != nil {
+		return nil, err
+	}
+
+	return []map[string]string{
+		prepareResults(txtrecords),
+	}, nil
+}
+
+func (odns *OpenDNS) Logger() (string, logger.LogFunc) {
+	return _PLUGIN_NAME, odns.Log
+}
+
+func (odns *OpenDNS) Log(ctx context.Context, typ logger.LogType, logText string) (err error) {
+	log.Printf("%s: %s\n", typ, logText)
+	return
+}
+
+func prepareResults(in []string) (ret map[string]string) {
+
+	ret = map[string]string{
+		_ACTIVE: fmt.Sprintf("%v", len(in)),
+	}
+
+	for _, txt := range in {
+		out := strings.Split(txt, " ")
+
+		// Remove last element in dnscrypt
+		// since we want dnscrypt status
+		if out[0] == "dnscrypt" {
+			out = out[:len(out)-1]
+		}
+
+		ret[out[0]] = out[len(out)-1]
+	}
+
+	return
+}
+
+func getTXTRecords(ctx context.Context, query string) ([]string, error) {
+	r := net.Resolver{}
+	return r.LookupTXT(ctx, query)
+	//return net.LookupTXT(query)
+}

--- a/osq-exts/tables/opendns/opendns.go
+++ b/osq-exts/tables/opendns/opendns.go
@@ -56,6 +56,11 @@ func (odns *OpenDNS) Log(ctx context.Context, typ logger.LogType, logText string
 func prepareResults(in []string) (ret []map[string]string) {
 
 	for _, txt := range in {
+
+		if txt == "" {
+			continue
+		}
+
 		split := strings.Split(txt, " ")
 		out := make(map[string]string)
 		out[_KEY] = split[0]

--- a/osq-exts/tables/opendns/opendns.go
+++ b/osq-exts/tables/opendns/opendns.go
@@ -26,8 +26,8 @@ func New() (odns *OpenDNS, err error) {
 
 func (odns *OpenDNS) Columns() []table.ColumnDefinition {
 	return []table.ColumnDefinition{
-		table.BigIntColumn(_KEY),
-		table.BigIntColumn(_VALUE),
+		table.TextColumn(_KEY),
+		table.TextColumn(_VALUE),
 	}
 }
 
@@ -56,10 +56,15 @@ func (odns *OpenDNS) Log(ctx context.Context, typ logger.LogType, logText string
 func prepareResults(in []string) (ret []map[string]string) {
 
 	for _, txt := range in {
-		out := strings.Split(txt, " ")
-		tmp := make(map[string]string)
-		tmp[out[0]] = txt
-		ret = append(ret, tmp)
+		split := strings.Split(txt, " ")
+		out := make(map[string]string)
+		out[_KEY] = split[0]
+
+		if len(split[1:]) > 0 {
+			out[_VALUE] = strings.Join(split[1:], " ")
+		}
+
+		ret = append(ret, out)
 	}
 
 	return

--- a/osq-exts/tables/opendns/opendns_test.go
+++ b/osq-exts/tables/opendns/opendns_test.go
@@ -17,6 +17,14 @@ var (
 		"user id 5e4d3c2b1a",
 		"dnscrypt enabled (1234)",
 	}
+
+	_SINGLE_ELEMENT_RECORD = []string{
+		"single_element_test",
+	}
+
+	_BLANK_KEY_TEST = []string{
+		"",
+	}
 )
 
 func TestTXTRecords(t *testing.T) {
@@ -28,8 +36,26 @@ func TestTXTRecords(t *testing.T) {
 	}
 }
 
+func TestPrepareWithBlankKey(t *testing.T) {
+	results := prepareResults(_BLANK_KEY_TEST)
+
+	if len(results) > 1 {
+		t.Fatal("should be blank")
+	}
+
+}
+
+func TestPrepareWithSingleElementRecord(t *testing.T) {
+	results := prepareResults(_SINGLE_ELEMENT_RECORD)
+
+	if len(results) != len(_SINGLE_ELEMENT_RECORD) {
+		t.Fatal("len not equal")
+	}
+}
+
 func TestPrepareWithResults(t *testing.T) {
 	results := prepareResults(_FAKE_TXT_RECORDS)
+
 	if len(results) != len(_FAKE_TXT_RECORDS) {
 		t.Fatal("len not equal")
 	}

--- a/osq-exts/tables/opendns/opendns_test.go
+++ b/osq-exts/tables/opendns/opendns_test.go
@@ -1,0 +1,44 @@
+package opendns
+
+import (
+        "testing"
+		"context"
+)
+
+var (
+        _FAKE_TXT_RECORDS = []string{
+                "server m1234.home",
+                "originid 1234567890",
+                "source 127.0.0.1:1337",
+                "actype 0",
+                "orgid 123456",
+                "bundle 7890",
+                "device a1b2c3d4e5",
+                "user id 5e4d3c2b1a",
+                "dnscrypt enabled (1234)",
+        }
+)
+
+func TestTXTRecords(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := getTXTRecords(ctx, _DEBUG_OPENDNS)
+	if err != nil {
+			t.Fatalf("err %v", err)
+	}
+}
+
+func TestPrepareWithResults(t *testing.T) {
+        results := prepareResults(_FAKE_TXT_RECORDS)
+        if len(results) != len(_FAKE_TXT_RECORDS)+1 {
+                t.Fatal("len not equal")
+        }
+}
+
+func TestPrepareWithoutResults(t *testing.T) {
+        norecords := make([]string, 0)
+        results := prepareResults(norecords)
+        if len(results) != 1 {
+                t.Fatalf("results do not match")
+        }
+}

--- a/osq-exts/tables/opendns/opendns_test.go
+++ b/osq-exts/tables/opendns/opendns_test.go
@@ -1,22 +1,22 @@
 package opendns
 
 import (
-        "testing"
-		"context"
+	"context"
+	"testing"
 )
 
 var (
-        _FAKE_TXT_RECORDS = []string{
-                "server m1234.home",
-                "originid 1234567890",
-                "source 127.0.0.1:1337",
-                "actype 0",
-                "orgid 123456",
-                "bundle 7890",
-                "device a1b2c3d4e5",
-                "user id 5e4d3c2b1a",
-                "dnscrypt enabled (1234)",
-        }
+	_FAKE_TXT_RECORDS = []string{
+		"server m1234.home",
+		"originid 1234567890",
+		"source 127.0.0.1:1337",
+		"actype 0",
+		"orgid 123456",
+		"bundle 7890",
+		"device a1b2c3d4e5",
+		"user id 5e4d3c2b1a",
+		"dnscrypt enabled (1234)",
+	}
 )
 
 func TestTXTRecords(t *testing.T) {
@@ -24,21 +24,21 @@ func TestTXTRecords(t *testing.T) {
 
 	_, err := getTXTRecords(ctx, _DEBUG_OPENDNS)
 	if err != nil {
-			t.Fatalf("err %v", err)
+		t.Fatalf("err %v", err)
 	}
 }
 
 func TestPrepareWithResults(t *testing.T) {
-        results := prepareResults(_FAKE_TXT_RECORDS)
-        if len(results) != len(_FAKE_TXT_RECORDS)+1 {
-                t.Fatal("len not equal")
-        }
+	results := prepareResults(_FAKE_TXT_RECORDS)
+	if len(results) != len(_FAKE_TXT_RECORDS) {
+		t.Fatal("len not equal")
+	}
 }
 
 func TestPrepareWithoutResults(t *testing.T) {
-        norecords := make([]string, 0)
-        results := prepareResults(norecords)
-        if len(results) != 1 {
-                t.Fatalf("results do not match")
-        }
+	norecords := make([]string, 0)
+	results := prepareResults(norecords)
+	if len(results) != 0 {
+		t.Fatalf("results do not match")
+	}
 }


### PR DESCRIPTION
This table reads information from debug.opendns.com for diagnostic information.

macOS, Windows, and Linux are supported.

```
osquery> select * from opendns;
+--------------+-------------------------------------------------------+
| key          | value                                                 |
+--------------+-------------------------------------------------------+
| server       | m1234.abcd                                            |
| device       | 1234567890123456                                      |
| organization | id 123456                                             |
| alt          | uid 123412341234123412341234123412341                 |
| remoteip     | 192.168.0.1                                           |
| flags        | 00000000 0 00 000000000000000000000000000000000000000 |
| originid     | 123456789                                             |
| orgid        | 123456                                                |
| orgflags     | 12345678                                              |
| actype       | X                                                     |
| bundle       | 1234567                                               |
| source       | 1.2.3.4:51280                                         |
| dnscrypt     | enabled (0000000000000000)                            |
+--------------+-------------------------------------------------------+
osquery> select * from opendns where key='server';
+--------+---------+
| key    | value   |
+--------+---------+
| server | m12.345 |
+--------+---------+
osquery>
```
