### PR TITLE
Add macOS MDM profiles and Windows support.

### DIFF
--- a/chef/cookbooks/cpe_zoom/README.md
+++ b/chef/cookbooks/cpe_zoom/README.md
@@ -1,6 +1,6 @@
 cpe_zoom Cookbook
 ========================
-Install a profile to manage diagnostic information submission settings.
+Manages Zoom Desktop Client configuration on macOS and Windows.
 
 
 Attributes
@@ -9,18 +9,23 @@ Attributes
 
 Usage
 -----
-The profile will manage the `us.zoom.config` preference domain.
+On macOS, a profile will manage the `us.zoom.config` preference domain.
 
-The profile's organization key defaults to `Uber` unless `node['organization']` is
+The profile's organization key defaults to `Uber`, unless `node['organization']` is
 configured in your company's custom init recipe. The profile will also use
 whichever prefix is set in node['cpe_profiles']['prefix'], which defaults to `com.facebook.chef`
 
-The profile delivers a payload for the above keys in `node['cpe_zoom']`.  The three provided have a sane default, which can be overridden in another recipe if desired.
+The profile delivers a payload for the above keys in `node['cpe_zoom']`. The three provided have a sensible default, which can be overridden in another recipe if desired.
 
-This cookbook provides zero keys within the default attributes as there are many undocumented keys.
+This cookbook doesn't provide any keys within the default attributes as there are many undocumented keys.
 
-For a list of supported keys, please see this [Zoom knowledge base article](https://support.zoom.us/hc/en-us/articles/115001799006-Mass-Deployment-with-Preconfigured-Settings-for-Mac)
+On Windows, take care not to deploy Zoom with MSI install arguments which conflict with the registry keys you set via this cookbook.
 
-For example, you could tweak the above values
-    # Disable the ability for Zoom to turn on your webcam when joining a meeting.
+For a list of supported configuration keys, please see the Zoom knowledge base articles for [macOS](https://support.zoom.us/hc/en-us/articles/115001799006-Mass-Deployment-with-Preconfigured-Settings-for-Mac) and [Windows](https://support.zoom.us/hc/en-us/articles/201362163).
+
+Example
+-----
+```ruby
+    # Disable activating your webcam when joining meetings.
     node.default['cpe_zoom']['ZDisableVideo'] = true
+```

--- a/chef/cookbooks/cpe_zoom/metadata.rb
+++ b/chef/cookbooks/cpe_zoom/metadata.rb
@@ -7,5 +7,3 @@ version '0.1.0'
 chef_version '>= 14.14'
 
 depends 'cpe_profiles'
-depends 'cpe_utils'
-depends 'uber_helpers'

--- a/chef/cookbooks/cpe_zoom/resources/cpe_zoom.rb
+++ b/chef/cookbooks/cpe_zoom/resources/cpe_zoom.rb
@@ -2,8 +2,6 @@
 # Cookbook:: cpe_zoom
 # Resources:: cpe_zoom
 #
-# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
-#
 # Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
@@ -17,21 +15,110 @@ provides :cpe_zoom, :os => 'darwin'
 
 default_action :run
 
-# Enforce Zoom Settings
-action :run do
-  zoom_prefs = node['cpe_zoom'].compact
-  unless zoom_prefs.empty?
-    zoom_prefs.each_key do |key|
-      next if zoom_prefs[key].nil?
+action_class do
+  WINDOWS_GENERAL_SETTINGS_MAP = {
+    "ZAutoSSOLogin" => "ForceLoginWithSSO",
+    "ZSSOHost" => "ForceSSOURL",
+    "ZAutoUpdate" => "EnableClientAutoUpdate",
+    "disableloginwithemail" => "DisableLoginWithEmail",
+    "nofacebook" => "DisableFacebookLogin",
+    "nogoogle" => "DisableGoogleLogin",
+  }.freeze
 
-      # Zoom doesn't use profiles atm. Chef 14+
-      if node.at_least_chef14?
+  WINDOWS_CHAT_SETTINGS_MAP = {
+    "DisableLinkPreviewInChat" => "DisableLinkPreviewInChat",
+  }.freeze
+
+  WINDOWS_IGNORABLE_SETTINGS_MAP = [
+    "LastLoginType",
+    "forcessourl", # ZSSOHost is already mapped to ForceSSOURL
+  ].freeze
+
+  def zoom_prefs
+    node["cpe_zoom"].compact
+  end
+
+  def convert_to_registry_key(value)
+    if value == true
+      return { "data": 1, "type": :dword }
+    elsif value == false
+      return { "data": 0, "type": :dword }
+    else
+      return { "data": value.to_s, "type": :string }
+    end
+  end
+
+  def configure_windows
+    zoom_settings = {}
+    zoom_prefs.each do |key, value|
+      next if WINDOWS_IGNORABLE_SETTINGS_MAP.include?(key) # Skippable preferences on Windows
+
+      preference = WINDOWS_CHAT_SETTINGS_MAP[key]
+      if preference.nil? # If the preference isn't in WINDOWS_CHAT_SETTINGS_MAP, set General path.
+        zoom_settings[WINDOWS_GENERAL_SETTINGS_MAP.fetch(key, key)] = { "path": 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Zoom\Zoom Meetings\General', "name": WINDOWS_GENERAL_SETTINGS_MAP.fetch(key, key) }.merge(convert_to_registry_key(value))
+      else
+        zoom_settings[preference] = { "path": 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Zoom\Zoom Meetings\chat', "name": key }.merge(convert_to_registry_key(value))
+      end
+    end
+
+    unless zoom_settings.empty?
+      zoom_settings.each do | name, reg_key |
+        registry_key reg_key[:path] do
+          values [{ name: reg_key[:name], type: reg_key[:type], data: reg_key[:data] }]
+          recursive true
+          action :create
+        end
+      end
+    end
+
+  end
+
+  def configure_macos
+    prefix = node["cpe_profiles"]["prefix"]
+    organization = node["organization"] || "Uber"
+    zoom_profile = {
+      "PayloadIdentifier" => "#{prefix}.zoom",
+      "PayloadRemovalDisallowed" => true,
+      "PayloadScope" => "System",
+      "PayloadType" => "Configuration",
+      "PayloadUUID" => "B1B0DEED-DC7C-4122-912F-A22F660DF53D",
+      "PayloadOrganization" => organization,
+      "PayloadVersion" => 1,
+      "PayloadDisplayName" => "Zoom",
+      "PayloadContent" => [],
+    }
+    unless zoom_prefs.empty?
+      zoom_profile["PayloadContent"].push(
+        "PayloadType" => "us.zoom.config",
+        "PayloadVersion" => 1,
+        "PayloadIdentifier" => "#{prefix}.zoom",
+        "PayloadUUID" => "B976C3E1-B59D-4060-80DA-13A42270D1E7",
+        "PayloadEnabled" => true,
+        "PayloadDisplayName" => "Zoom",
+      )
+      zoom_prefs.each_key do |key|
+        next if zoom_prefs[key].nil?
+        zoom_profile["PayloadContent"][0][key] = zoom_prefs[key]
+        # Double tap the preferences since Zoom didn't use profiles at one point. Requires Chef 14 or newer
         macos_userdefaults "Configure us.zoom.config - #{key}" do
-          domain '/Library/Preferences/us.zoom.config'
+          domain "/Library/Preferences/us.zoom.config"
           key key
           value zoom_prefs[key]
         end
       end
     end
+
+    node.default["cpe_profiles"]["#{prefix}.zoom"] = zoom_profile
+  end
+end
+
+# Enforce Zoom Settings
+action :run do
+  return if zoom_prefs.empty?
+
+  if macos?
+    configure_macos
+  elsif windows?
+    configure_windows
   end
 end


### PR DESCRIPTION
We forked this cookbook at some point and have drifted quite a bit, so I'm submitting our changes upstream.

This PR adds Windows support by using Zoom's [registry keys](https://support.zoom.us/hc/en-us/articles/360039100051), so we can configure the client on-the-fly rather than at install/upgrade.

Tested by running on a fresh Zoom install, Zoom installed via Chef with Chocolatey/MSI flags, and standalone Zoom without install-time flags. In my testing, registry keys take precedence over MSI flags, which allows pushing this out to existing install-bases.

Applying new settings via the registry merely requires quitting and reopening Zoom.