### PR TITLE
Remove cpe_utils dep from uber_helpers

### DIFF
--- a/chef/cookbooks/uber_helpers/README.md
+++ b/chef/cookbooks/uber_helpers/README.md
@@ -2,13 +2,7 @@ uber_helpers Cookbook
 ==================
 This cookbook is where we keep all the common function / classes for use with chef.
 
-This cookbook depends on the following cookbook:
-
-* [cpe_utils](https://github.com/facebook/IT-CPE/tree/master/chef/cookbooks/cpe_utils)
-
-This cookbook is offered by Facebook in the [IT-CPE](https://github.com/facebook/IT-CPE) repository.
-
-This cookbook also depends on the following tools
+This cookbook depends on the following tools
 
 * [gnes](https://github.com/erikng/gnes)
 

--- a/chef/cookbooks/uber_helpers/metadata.rb
+++ b/chef/cookbooks/uber_helpers/metadata.rb
@@ -4,5 +4,3 @@ maintainer_email 'noreply@uber.com'
 license 'Apache-2.0'
 description 'Uber helper functions and libraries'
 version '0.1.0'
-
-depends 'cpe_utils'


### PR DESCRIPTION
This cookbook doesn't use any cpe_utils functions, plus cpe_utils is long gone.